### PR TITLE
OneUI-like settings actionbar [3/3]

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1124,4 +1124,9 @@
     <string name="alarm_blocker_reload">Reload</string>
     <string name="alarm_blocker_warning_title">Proceed with caution</string>
     <string name="alarm_blocker_warning">Blocking alarms have the potential to cause instability, crashes or data loss.</string>
+
+    <!-- R Notification headers -->
+    <string name="notification_headers_title">Show notification headers</string>
+    <string name="notification_headers_summary">Whether to show R style notification headers (Requires a SystemUI restart)</string>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1129,4 +1129,6 @@
     <string name="notification_headers_title">Show notification headers</string>
     <string name="notification_headers_summary">Whether to show R style notification headers (Requires a SystemUI restart)</string>
 
+    <string name="enable_oneui">OneUI</string>
+    <string name="enable_oneui_summary">Show spacer above settings actionbar for easier use with one hand\nNOTE: restart settings app to see effect</string>
 </resources>

--- a/res/xml/miscellaneous.xml
+++ b/res/xml/miscellaneous.xml
@@ -87,6 +87,12 @@
            android:summary="@string/device_identifier_access_restrictions_summary"
            android:defaultValue="false" />
 
+       <com.dirtyunicorns.support.preferences.SystemSettingSwitchPreference
+           android:key="settings_spacer"
+           android:title="@string/enable_oneui"
+           android:summary="@string/enable_oneui_summary"
+           android:defaultValue="false" />
+
     <!-- Launch music player when headset is connected -->
         <com.dirtyunicorns.support.preferences.SystemSettingSwitchPreference
            android:key="headset_connect_player"

--- a/res/xml/notifications.xml
+++ b/res/xml/notifications.xml
@@ -43,6 +43,12 @@
             android:summary="@string/enable_fc_notifications_summary" 
             android:defaultValue="true" /> 
 
+        <com.dirtyunicorns.support.preferences.SystemSettingSwitchPreference
+            android:key="notification_headers"
+            android:title="@string/notification_headers_title"
+            android:summary="@string/notification_headers_summary"
+            android:defaultValue="true" />
+
         <com.dirtyunicorns.support.preferences.SystemSettingSwitchPreference 
             android:key="charging_animation"
             android:title="@string/charging_animation_title"


### PR DESCRIPTION
todo: add settings observer so you won't need to restart settings app to toggle it

xawlw:
Disabled by default

